### PR TITLE
Use async_update_entry to update options properly

### DIFF
--- a/custom_components/crunch_o_meter/__init__.py
+++ b/custom_components/crunch_o_meter/__init__.py
@@ -19,7 +19,10 @@ async def async_setup_entry(hass, config_entry):
         VERSION,
         ISSUE_URL,
     )
-    config_entry.options = config_entry.data
+    # UPDATE 10/18/24 - Use async_update_entry to update options properly in newer HA versions
+    hass.config_entries.async_update_entry(
+        config_entry, options=config_entry.data
+    )
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(config_entry, PLATFORM)
     )

--- a/custom_components/crunch_o_meter/__init__.py
+++ b/custom_components/crunch_o_meter/__init__.py
@@ -19,7 +19,6 @@ async def async_setup_entry(hass, config_entry):
         VERSION,
         ISSUE_URL,
     )
-    # UPDATE 10/18/24 - Use async_update_entry to update options properly in newer HA versions
     hass.config_entries.async_update_entry(
         config_entry, options=config_entry.data
     )


### PR DESCRIPTION
Fix for error in Home Assistant 2024.10.+ / OS 13.2

Error:
File "/config/custom_components/crunch_o_meter/__init__.py", line 22, in async_setup_entry
    config_entry.options = config_entry.data
    ^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 443, in __setattr__
    raise AttributeError(
AttributeError: options cannot be changed directly, use async_update_entry instead