### PR TITLE
Update __init__.py for new HomeAssistant Beta

### DIFF
--- a/custom_components/crunch_o_meter/__init__.py
+++ b/custom_components/crunch_o_meter/__init__.py
@@ -23,7 +23,7 @@ async def async_setup_entry(hass, config_entry):
         config_entry, options=config_entry.data
     )
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(config_entry, PLATFORM)
+        hass.config_entries.async_forward_entry_setups(config_entry, PLATFORM)
     )
     return True
 


### PR DESCRIPTION
I'm running the latest beta and this integration fails to initialize. I fixed it on my instance and figured I'd push up the little change.